### PR TITLE
Prevent atom selection and send event object

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,13 @@
     "test": "npm run test-only && npm run eslint",
     "test-only": "cross-env NODE_ENV=test jest"
   },
+  "prettier": {
+    "arrowParens": "always",
+    "tabWidth": 2,
+    "singleQuote": true,
+    "semi": true,
+    "trailingComma": "all"
+  },
   "license": "MIT",
   "dependencies": {
     "prop-types": "^15.7.2"

--- a/src/components/SvgRenderer.js
+++ b/src/components/SvgRenderer.js
@@ -78,21 +78,21 @@ function useEvents(ref, start, onEnter, onLeave, onClick) {
       if (!onEnter) return;
       const { target } = event;
       if (target.className.baseVal === 'event' && target.id.startsWith(start)) {
-        onEnter(Number(target.id.replace(start, '')));
+        onEnter(Number(target.id.replace(start, '')), event);
       }
     };
     const handleLeave = (event) => {
       if (!onLeave) return;
       const { target } = event;
       if (target.className.baseVal === 'event' && target.id.startsWith(start)) {
-        onLeave(Number(target.id.replace(start, '')));
+        onLeave(Number(target.id.replace(start, '')), event);
       }
     };
     const handleClick = (event) => {
       if (!onClick) return;
       const { target } = event;
       if (target.className.baseVal === 'event' && target.id.startsWith(start)) {
-        onClick(Number(target.id.replace(start, '')));
+        onClick(Number(target.id.replace(start, '')), event);
       }
     };
     svg.addEventListener('mouseover', handleEnter);

--- a/src/components/SvgRenderer.js
+++ b/src/components/SvgRenderer.js
@@ -59,6 +59,7 @@ export default function SvgRenderer(props) {
 
   return (
     <div
+      style={{ userSelect: 'none' }}
       ref={ref}
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{

--- a/src/components/__tests__/__snapshots__/SvgRenderer.js.snap
+++ b/src/components/__tests__/__snapshots__/SvgRenderer.js.snap
@@ -103,6 +103,11 @@ exports[`Molecule renders molfile with default id 1`] = `
 </svg>",
     }
   }
+  style={
+    Object {
+      "userSelect": "none",
+    }
+  }
 />
 `;
 
@@ -124,6 +129,11 @@ exports[`Molecule renders smiles with custom id 1`] = `
   <circle id=\\"mol1:Atom:2\\" class=\\"event\\" cx=\\"589.61\\" cy=\\"394\\" r=\\"8\\" opacity=\\"0\\" />
   <circle id=\\"mol1:Atom:3\\" class=\\"event\\" cx=\\"568.82\\" cy=\\"406\\" r=\\"8\\" opacity=\\"0\\" />
 </svg>",
+    }
+  }
+  style={
+    Object {
+      "userSelect": "none",
     }
   }
 />

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 import { IMoleculeToSVGOptions, Molecule } from 'openchemlib/minimal';
-import { ComponentType } from 'react';
+import { ComponentType, MouseEvent } from 'react';
 
 // Minimal and core APIs
 
@@ -18,16 +18,16 @@ export interface IBaseSvgRendererProps extends IMoleculeToSVGOptions {
   atomHighlight?: number[];
   atomHighlightOpacity?: number;
   atomHighlightColor?: string;
-  onAtomEnter?: (atomId: number, event: React.MouseEvent<SVGElement>) => void;
-  onAtomLeave?: (atomId: number, event: React.MouseEvent<SVGElement>) => void;
-  onAtomClick?: (atomId: number, event: React.MouseEvent<SVGElement>) => void;
+  onAtomEnter?: (atomId: number, event: MouseEvent<SVGElement>) => void;
+  onAtomLeave?: (atomId: number, event: MouseEvent<SVGElement>) => void;
+  onAtomClick?: (atomId: number, event: MouseEvent<SVGElement>) => void;
 
   bondHighlight?: number[];
   bondHighlightOpacity?: number;
   bondHighlightColor?: string;
-  onBondEnter?: (bondId: number, event: React.MouseEvent<SVGElement>) => void;
-  onBondLeave?: (bondId: number, event: React.MouseEvent<SVGElement>) => void;
-  onBondClick?: (bondId: number, event: React.MouseEvent<SVGElement>) => void;
+  onBondEnter?: (bondId: number, event: MouseEvent<SVGElement>) => void;
+  onBondLeave?: (bondId: number, event: MouseEvent<SVGElement>) => void;
+  onBondClick?: (bondId: number, event: MouseEvent<SVGElement>) => void;
 }
 
 export interface ISmilesSvgRendererProps extends IBaseSvgRendererProps {

--- a/types.d.ts
+++ b/types.d.ts
@@ -18,16 +18,16 @@ export interface IBaseSvgRendererProps extends IMoleculeToSVGOptions {
   atomHighlight?: number[];
   atomHighlightOpacity?: number;
   atomHighlightColor?: string;
-  onAtomEnter?: (atomId: number) => void;
-  onAtomLeave?: (atomId: number) => void;
-  onAtomClick?: (atomId: number) => void;
+  onAtomEnter?: (atomId: number, event: React.MouseEvent<SVGElement>) => void;
+  onAtomLeave?: (atomId: number, event: React.MouseEvent<SVGElement>) => void;
+  onAtomClick?: (atomId: number, event: React.MouseEvent<SVGElement>) => void;
 
   bondHighlight?: number[];
   bondHighlightOpacity?: number;
   bondHighlightColor?: string;
-  onBondEnter?: (bondId: number) => void;
-  onBondLeave?: (bondId: number) => void;
-  onBondClick?: (bondId: number) => void;
+  onBondEnter?: (bondId: number, event: React.MouseEvent<SVGElement>) => void;
+  onBondLeave?: (bondId: number, event: React.MouseEvent<SVGElement>) => void;
+  onBondClick?: (bondId: number, event: React.MouseEvent<SVGElement>) => void;
 }
 
 export interface ISmilesSvgRendererProps extends IBaseSvgRendererProps {


### PR DESCRIPTION
I need to make difference between shift + click, alt + click, etc so I thought about sending the event object.